### PR TITLE
SceneManager Class, Serialization support, Game object retrieval from scene files.

### DIFF
--- a/HorizonEditor/CMakeLists.txt
+++ b/HorizonEditor/CMakeLists.txt
@@ -27,6 +27,15 @@ add_custom_command(
 	$<TARGET_FILE_DIR:HznEditor>/assets
 )
 
+add_custom_command(
+	TARGET HznEditor
+	POST_BUILD
+	COMMAND ${CMAKE_COMMAND}
+	ARGS -E copy_directory
+	${CMAKE_CURRENT_LIST_DIR}/scenes
+	$<TARGET_FILE_DIR:HznEditor>/scenes
+)
+
 # post build commands to copy resources from source to build directories for the HorizonEngine target
 add_custom_command(
 	TARGET HznEditor

--- a/HorizonEditor/include/EditorLayer.h
+++ b/HorizonEditor/include/EditorLayer.h
@@ -6,15 +6,15 @@ class EditorLayer : public Hzn::Layer
 {
 public:
 	EditorLayer(const char* name = "Editor Layer");
-	virtual ~EditorLayer() {}
+	virtual ~EditorLayer();
 	virtual void onAttach() override;
 	virtual void onDetach() override;
 	virtual void onUpdate(Hzn::TimeStep deltaTime) override;
 	virtual void onEvent(Hzn::Event& event) override;
 	virtual void onRenderImgui() override;
-	bool onWindowResize(Hzn::WindowResizeEvent& e);
 
 private:
+	void destroy();
 	int32_t quads = 10;
 	float quadAngle = 0.0f;
 	float m_AspectRatio = 1.0f;
@@ -26,6 +26,7 @@ private:
 	bool m_ViewportHovered = false;
 
 	std::shared_ptr<Hzn::Scene> m_Scene;
+	std::shared_ptr<Hzn::SceneManager> m_SceneManager;
 	Hzn::GameObject m_SquareObject;
 	Hzn::GameObject m_SquareObject2;
 	Hzn::GameObject m_Camera;

--- a/HorizonEngine/CMakeLists.txt
+++ b/HorizonEngine/CMakeLists.txt
@@ -45,7 +45,7 @@ set(HZN_SOURCE_FILES
 	"src/HorizonEngine/Renderer/Renderer3D.cpp"
 	"src/HorizonEngine/Renderer/Sprite.cpp"
 	"src/HorizonEngine/Renderer/FrameBuffer.cpp"
-	"Platform/OpenGL/GLFrameBuffer.cpp" )
+	"Platform/OpenGL/GLFrameBuffer.cpp"  "src/HorizonEngine/SceneManagement/SceneManager.cpp")
 
 set(HZN_HEADER_FILES
 	"HorizonEngine.h"
@@ -98,7 +98,7 @@ set(HZN_HEADER_FILES
 	"src/HorizonEngine/Renderer/Renderer3D.h"
 	"src/HorizonEngine/Renderer/Sprite.h"
 	"src/HorizonEngine/Renderer/FrameBuffer.h"
-	"Platform/OpenGL/GLFrameBuffer.h" "src/HorizonEngine/SceneManagement/GameObject.h")
+	"Platform/OpenGL/GLFrameBuffer.h" "src/HorizonEngine/SceneManagement/GameObject.h" "src/HorizonEngine/SceneManagement/SceneManager.h")
 
 # Add source to this project's executable.
 add_library (HorizonEngine ${HZN_SOURCE_FILES} ${HZN_HEADER_FILES})

--- a/HorizonEngine/HorizonEngine.h
+++ b/HorizonEngine/HorizonEngine.h
@@ -35,6 +35,7 @@
 #include "HorizonEngine/FileManagement/ProjectFile.h"
 
 #include "HorizonEngine/SceneManagement/Scene.h"
+#include "HorizonEngine/SceneManagement/SceneManager.h"
 #include "HorizonEngine/SceneManagement/GameObject.h"
 
 #include "HorizonEngine/Input.h"

--- a/HorizonEngine/src/HorizonEngine/Camera/Camera.h
+++ b/HorizonEngine/src/HorizonEngine/Camera/Camera.h
@@ -6,7 +6,7 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/type_ptr.hpp>
-#include <glm/detail/compute_common.hpp>
+//#include <cereal/access.hpp>
 
 namespace Hzn
 {
@@ -338,6 +338,7 @@ namespace Hzn
 	class SceneCamera2D : public Camera
 	{
 	public:
+		/*friend class cereal::access;*/
 		SceneCamera2D(const float aspectRatio, const float zoom) :
 			m_AspectRatio(aspectRatio),
 			m_Zoom(zoom)
@@ -367,6 +368,28 @@ namespace Hzn
 		{
 			m_Zoom = zoom;
 			calculateProjectionMatrix();
+		}
+
+		template<typename Archive>
+		void load(Archive& ar)
+		{
+			ar(m_Zoom);
+
+			for(int i = 0; i < 4; ++i)
+			{
+				ar(m_Projection[i].x, m_Projection[i].y, m_Projection[i].z, m_Projection[i].w);
+			}
+		}
+
+		template<typename Archive>
+		void save(Archive& ar) const
+		{
+			ar(m_Zoom);
+
+			for (int i = 0; i < 4; ++i)
+			{
+				ar(m_Projection[i].x, m_Projection[i].y, m_Projection[i].z, m_Projection[i].w);
+			}
 		}
 
 	private:

--- a/HorizonEngine/src/HorizonEngine/Components/Component.h
+++ b/HorizonEngine/src/HorizonEngine/Components/Component.h
@@ -8,6 +8,30 @@
 
 namespace Hzn
 {
+	struct NameComponent
+	{
+		NameComponent() = default;
+		NameComponent(const NameComponent& name) = default;
+		NameComponent(const std::string& name): m_Name(name) {}
+		~NameComponent() = default;
+
+		operator std::string() const & { return m_Name; }
+		operator std::string()& { return m_Name; }
+		std::string m_Name;
+
+		template<typename Archive>
+		void load(Archive& ar)
+		{
+			ar(m_Name);
+		}
+
+		template<typename Archive>
+		void save(Archive& ar) const
+		{
+			ar(m_Name);
+		}
+	};
+
 	struct TransformComponent
 	{
 		TransformComponent() = default;
@@ -18,7 +42,26 @@ namespace Hzn
 		operator const glm::mat4() const & { return m_Transform; }
 		operator glm::mat4() & { return m_Transform; }
 		glm::mat4 m_Transform = glm::mat4(1.0f);
+
+		template<typename Archive>
+		void load(Archive& ar)
+		{
+			for(int i = 0; i < m_Transform.length(); ++i)
+			{
+				ar(m_Transform[i].x, m_Transform[i].y, m_Transform[i].z, m_Transform[i].w);
+			}
+		}
+
+		template<typename Archive>
+		void save(Archive& ar) const
+		{
+			for (int i = 0; i < m_Transform.length(); ++i)
+			{
+				ar(m_Transform[i].x, m_Transform[i].y, m_Transform[i].z, m_Transform[i].w);
+			}
+		}
 	};
+
 
 	struct RenderComponent
 	{
@@ -30,16 +73,40 @@ namespace Hzn
 		operator glm::vec4() & { return m_Color; }
 
 		glm::vec4 m_Color = glm::vec4(1.0f);
+
+		template<typename Archive>
+		void load(Archive& ar)
+		{
+			ar(m_Color.x, m_Color.y, m_Color.z, m_Color.w);
+		}
+
+		template<typename Archive>
+		void save(Archive& ar) const
+		{
+			ar(m_Color.x, m_Color.y, m_Color.z, m_Color.w);
+		}
 	};
 
 	struct CameraComponent
 	{
-		CameraComponent(const float aspectRatio, const float zoom)
+		CameraComponent(const float aspectRatio = 1.0f, const float zoom = 1.0f)
 			: m_Camera(aspectRatio, zoom) {}
 		
 		~CameraComponent() = default;
 		SceneCamera2D m_Camera;
 		bool m_Primary = true;
+
+		template<typename Archive>
+		void load(Archive& ar)
+		{
+			ar(m_Camera, m_Primary);
+		}
+
+		template<typename Archive>
+		void save(Archive& ar) const
+		{
+			ar(m_Camera, m_Primary);
+		}
 	};
 
 }

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/Scene.cpp
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/Scene.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 
 #include "HorizonEngine/Renderer/Renderer2D.h"
-
 #include "Scene.h"
 #include "GameObject.h"
 #include "HorizonEngine/Components/Component.h"
@@ -10,9 +9,32 @@ namespace Hzn
 {
 	Scene::Scene(): m_Registry(entt::registry()) {}
 
+	Scene::Scene(cereal::JSONInputArchive& inputArchive)
+		: m_Registry(entt::registry())
+	{
+		entt::snapshot_loader loader(m_Registry);
+		loader.entities(inputArchive).component<NameComponent, TransformComponent, RenderComponent, CameraComponent>(inputArchive);
+
+		// since all valid objects have name components we create a view on name components
+		const auto& view = m_Registry.view<NameComponent>();
+
+		// create all the game objects from the registry.
+		for(const auto& entity : view)
+		{
+			m_Objects.insert({ view.get<NameComponent>(entity), {entity, this} });
+		}
+	}
+
 	Scene::~Scene()
 	{
 		m_Registry.clear();
+	}
+
+	void Scene::serialize(cereal::JSONOutputArchive& outputArchive)
+	{
+		entt::snapshot{ m_Registry }
+			.entities(outputArchive)
+			.component<NameComponent, TransformComponent, RenderComponent, CameraComponent>(outputArchive);
 	}
 
 	glm::vec2 Scene::onViewportResize(uint32_t width, uint32_t height)
@@ -20,12 +42,15 @@ namespace Hzn
 		// update all the camera components on viewport resize.
 		if(glm::vec2(width, height) != m_lastViewportSize)
 		{
-			const auto& view = m_Registry.view<CameraComponent>();
-
-			for(const auto& entity : view)
+			if (m_Valid)
 			{
-				auto& camera = view.get<CameraComponent>(entity).m_Camera;
-				camera.setAspectRatio((float)width / height);
+				const auto& view = m_Registry.view<CameraComponent>();
+
+				for (const auto& entity : view)
+				{
+					auto& camera = view.get<CameraComponent>(entity).m_Camera;
+					camera.setAspectRatio((float)width / height);
+				}
 			}
 
 			m_lastViewportSize = glm::vec2(width, height);
@@ -37,39 +62,79 @@ namespace Hzn
 	void Scene::onUpdate(TimeStep ts)
 	{
 		// render objects in the scene through scene update.
-		const SceneCamera2D* activeCamera = nullptr;
-		const TransformComponent* cameraTransform = nullptr;
+		if (m_Valid) {
+			const SceneCamera2D* activeCamera = nullptr;
+			const TransformComponent* cameraTransform = nullptr;
 
-		const auto& cameras = m_Registry.view<CameraComponent, TransformComponent>();
+			const auto& cameras = m_Registry.view<CameraComponent, TransformComponent>();
 
-		for(const auto& entity : cameras)
-		{
-			const auto& cameraComponent = cameras.get<CameraComponent>(entity);
-			const auto& transformComponent = cameras.get<TransformComponent>(entity);
-			if(cameraComponent.m_Primary)
+			for (const auto& entity : cameras)
 			{
-				activeCamera = &cameraComponent.m_Camera;
-				cameraTransform = &transformComponent;
+				const auto& cameraComponent = cameras.get<CameraComponent>(entity);
+				const auto& transformComponent = cameras.get<TransformComponent>(entity);
+				if (cameraComponent.m_Primary)
+				{
+					activeCamera = &cameraComponent.m_Camera;
+					cameraTransform = &transformComponent;
+				}
 			}
-		}
 
-
-		if (activeCamera)
-		{
-			Renderer2D::beginScene(*activeCamera, *cameraTransform);
-			const auto& sprites = m_Registry.view<RenderComponent, TransformComponent>();
-			for (const auto& entity : sprites)
+			if (activeCamera) 
 			{
-				auto [renderComponent, transformComponent] = sprites.get<RenderComponent, TransformComponent>(entity);
-				Renderer2D::drawQuad(transformComponent, renderComponent);
+				Renderer2D::beginScene(*activeCamera, *cameraTransform);
+				const auto& sprites = m_Registry.view<RenderComponent, TransformComponent>();
+				for (const auto& entity : sprites)
+				{
+					auto [renderComponent, transformComponent] = sprites.get<RenderComponent, TransformComponent>(entity);
+					Renderer2D::drawQuad(transformComponent, renderComponent);
+				}
+				Renderer2D::endScene();
 			}
-			Renderer2D::endScene();
 		}
 	}
 
-	GameObject Scene::createGameObject()
+	GameObject Scene::createGameObject(const std::string& name)
 	{
-		return { m_Registry.create(), this };
+		if(!m_Valid)
+		{
+			throw std::runtime_error("Adding game object to invalidated scene!");
+		}
+
+		GameObject obj = { m_Registry.create(), this };
+		// every valid game object has a name component
+		obj.addComponent<NameComponent>(name);
+		m_Objects.insert({ name, obj });
+		return obj;
 	}
 
+	void Scene::destroyGameObject(GameObject& obj)
+	{
+		if (!m_Valid)
+		{
+			throw std::runtime_error("trying to get remove game objects from invalidated scene!");
+		}
+		// remove the game object from all objects list.
+		m_Registry.destroy(obj.m_ObjectId);
+		// remove object from the unordered_map.
+		m_Objects.erase(obj.getComponent<NameComponent>());
+		obj.m_ObjectId = entt::null;
+		obj.m_Scene = nullptr;
+	}
+
+	GameObject Scene::getGameObject(const std::string& name)
+	{
+		if (!m_Valid)
+		{
+			throw std::runtime_error("trying to get remove game objects from invalidated scene!");
+		}
+
+		auto it = m_Objects.find(name);
+
+		if(it == m_Objects.end())
+		{
+			throw std::runtime_error("Game object not found!");
+		}
+
+		return it->second;
+	}
 }

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/Scene.h
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/Scene.h
@@ -3,27 +3,53 @@
 #ifndef HZN_SCENE_H
 #define HZN_SCENE_H
 
-#include "HorizonEngine/Core/TimeStep.h"
 #include <entt/entt.hpp>
+#include <cereal/archives/json.hpp>
+#include <glm/glm.hpp>
+
+#include "HorizonEngine/Core/TimeStep.h"
 
 namespace Hzn
 {
-	class GameObject;
-	
+	class SceneManager;
+
 	class Scene
 	{
 		friend class GameObject;
+		friend class SceneManager;
 	public:
 		Scene();
+		Scene(cereal::JSONInputArchive& inputArchive);
 		~Scene();
 
 		glm::vec2 onViewportResize(uint32_t width, uint32_t height);
 		void onUpdate(TimeStep ts);
-		GameObject createGameObject();
+		/**
+		 * \brief creates a game object in the scene and returns a valid game object.
+		 * \return Valid Game Object.
+		 */
+		GameObject createGameObject(const std::string& name);
+		/**
+		 * \brief Deletes the game object from the scene, and invalidates the variable that
+		 * represented this Game object.
+		 * \param obj Reference to the Game Object.
+		 */
+		void destroyGameObject(GameObject& obj);
+
+		GameObject getGameObject(const std::string& name);
 
 	private:
+		void serialize(cereal::JSONOutputArchive& outputArchive);
+
+		// variable that is used by the scene manager to invalidate all
+		// the pointers to the scene. If the scene manager sets the scene.
+		// then those pointers cannot perform actions on the scene.
+		bool m_Valid = false;
 		// entt registry for creating game objects.
 		entt::registry m_Registry;
+
+		// unordered map for retrieving objects by name.
+		std::unordered_map<std::string, GameObject> m_Objects;
 		// viewport size of the scene. Helps in maintaining the aspect ratio of the scene.
 		glm::vec2 m_lastViewportSize = { 0.0f, 0.0f };
 	};

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/SceneManager.cpp
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/SceneManager.cpp
@@ -1,0 +1,86 @@
+#include "pch.h"
+
+#include <cereal/archives/json.hpp>
+
+#include "SceneManager.h"
+#include "Scene.h"
+
+namespace Hzn
+{
+	struct SceneDefaults
+	{
+		static uint32_t defaultCounter;
+		std::string filePath = "default_scene" + std::to_string(defaultCounter) + ".json";
+	};
+
+	uint32_t SceneDefaults::defaultCounter = 0;
+
+	static SceneDefaults defaults;
+
+	// filepath of the currently open scene file.
+	std::string SceneManager::s_FilePath = std::string();
+
+	std::shared_ptr<Scene> SceneManager::s_Scene = nullptr;
+
+
+	std::shared_ptr<Scene> SceneManager::load(const std::string& filepath)
+	{
+		if(s_Scene)
+		{
+			// serialize and safely close the currently playing scene.
+		}
+
+		s_FilePath = filepath;
+		// deserialize the coming scene and load it.
+		std::ifstream is(s_FilePath, std::ios::binary);
+		if (!filepath.empty())
+		{
+			try {
+				cereal::JSONInputArchive inputArchive(is);
+				// create the scene and make it valid for actions.
+				s_Scene = std::make_shared<Scene>(inputArchive);
+				s_Scene->m_Valid = true;
+				return s_Scene;
+			}
+			catch (const cereal::RapidJSONException& e)
+			{
+				//TODO: Scene corruption dialog.
+				const std::string& msg = "scene corruption";
+				throw std::runtime_error(msg + e.what());
+			}
+		}
+
+		// create the scene and make it valid for actions.
+		s_Scene = std::make_shared<Scene>();
+		s_Scene->m_Valid = true;
+		return s_Scene;
+	}
+
+	void SceneManager::close(const std::string& filepath)
+	{
+		// trying to close when there is no scene loaded!
+		if(!s_Scene)
+		{
+			throw std::runtime_error("no scene active!");
+		}
+
+		std::ofstream os(filepath, std::ios::binary);
+
+		if(!os)
+		{
+			throw std::runtime_error("failure on closing scene!");
+		}
+
+		cereal::JSONOutputArchive outputArchive(os);
+		// serialize the scene before closing.
+		s_Scene->serialize(outputArchive);
+
+		os << "\n}\n";
+
+		os.close();
+
+		// invalidate any external pointers to the scene.
+		s_Scene->m_Valid = false;
+		s_Scene.reset();
+	}
+}

--- a/HorizonEngine/src/HorizonEngine/SceneManagement/SceneManager.h
+++ b/HorizonEngine/src/HorizonEngine/SceneManagement/SceneManager.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifndef HZN_SCENE_MANAGER_H
+#define HZN_SCENE_MANAGER_H
+
+namespace Hzn
+{
+	class Scene;
+
+	class SceneManager
+	{
+	public:
+		static std::shared_ptr<Scene> load(const std::string& filepath = std::string());
+		static void close(const std::string& filepath);
+
+	private:
+		static std::string s_FilePath;
+		static std::shared_ptr<Scene> s_Scene;
+	};
+}
+
+#endif


### PR DESCRIPTION
- Implemented `SceneManager` class, Kind of owns the active scene and controls the validation and invalidation of Scene.
- Valid Scene is a scene that is active and to which, `GameObject`s can be added or removed. You cannot add or remove or get objects from an invalid scene (`GameObject`s are to be invalidated as well, when the scene is invalidated (this needs to be implemented)).
- Valid scenes can only be created through the `SceneManager`. You can create Scene objects through the default constructor, but those are invalid Scenes. (Maybe, I will make the constructors of the scene private).
- `SceneManager` is responsible for serializing and de-serializing the scene, hence it provides functions like load (can work like open), close (works like save as for now) and save (would just update the scene file with the latest snapshot of the Scene).
- `Scene` class holds `GameObject`s by name (specifically, all the game objects have a name component), which can be used to retrieve `GameObject`s from any scene (even if you have loaded it from a scene file not seen before, just the format should match)). This allows you to take a look at the all the available `GameObject`s in that Scene.